### PR TITLE
Re-order event import

### DIFF
--- a/web/modules/custom/event_pull/src/Service/EventLoader/GuzzleEventLoader.php
+++ b/web/modules/custom/event_pull/src/Service/EventLoader/GuzzleEventLoader.php
@@ -38,7 +38,7 @@ abstract class GuzzleEventLoader implements EventLoaderInterface {
 
     return collect(json_decode($events))->map(function (\stdClass $data) {
       return new Event($data);
-    })->sortByDesc(function (Event $event) {
+    })->sortBy(function (Event $event) {
       return $event->getEventDate();
     })->values();
   }


### PR DESCRIPTION
* Import events in the opposite order
* Import the older events first so that they have the lower node IDs.